### PR TITLE
Build in docker

### DIFF
--- a/build/scripts/build_helper
+++ b/build/scripts/build_helper
@@ -44,7 +44,12 @@ if [ $IS_CONTAINER -eq 0 ]
 then
   SUDO='sudo -S -E'
 else
-  SUDO=''
+  if [ -v FORCE_SUDO ]
+  then
+    SUDO='sudo'
+  else
+    SUDO=''
+  fi
 fi
 ###############################
 ## echo and  family
@@ -78,7 +83,7 @@ echo_success() { cecho "$*" $green        ;}
 echo_info()    { cecho "$*" $blue         ;}
 #-------------------------------------------------------------------------------
 # From https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
-# arg1 is a dotted (or not) version number (ex 4.10.6.56-ubunutu) 
+# arg1 is a dotted (or not) version number (ex 4.10.6.56-ubunutu)
 # arg2 is a dotted (or not) version number (ex 4.10.6.56-ubunutu)
 # return 0 if $1 lower or equal $2, else 1
 version_le() {
@@ -139,8 +144,8 @@ disable_ipv6() {
 # arg1 = version
 # arg2 = req_version
 #
-function version_gt() { 
-  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; 
+function version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
 }
 ###################################
 # Compilers

--- a/build/scripts/build_helper.fb_folly
+++ b/build/scripts/build_helper.fb_folly
@@ -47,7 +47,7 @@ install_fb_folly_from_source(){
 
   if [[ $prompt =~ [yY](es)* ]]
   then
- 
+
     $SUDO apt-get install $OPTION \
       g++ \
       cmake \
@@ -77,7 +77,7 @@ install_fb_folly_from_source(){
         libelf-dev \
         libdwarf-dev
       ret=$?;[[ $ret -ne 0 ]] && return $ret
-      
+
       wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz && \
       tar zxf release-1.8.0.tar.gz && \
       rm -f release-1.8.0.tar.gz && \
@@ -89,7 +89,7 @@ install_fb_folly_from_source(){
       cd ..
     fi
 
-    
+
     $SUDO rm -rf /tmp/folly
     git clone https://github.com/facebook/folly.git
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
@@ -98,7 +98,7 @@ install_fb_folly_from_source(){
     mkdir _build && cd _build
     cmake  ..
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
-    make -j $(nproc)
+    make $JNPROC
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
     $SUDO make install
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret

--- a/build/scripts/build_helper.libconfig
+++ b/build/scripts/build_helper.libconfig
@@ -29,7 +29,7 @@ THIS_SCRIPT_PATH=`dirname $SCRIPT`
 source $THIS_SCRIPT_PATH/build_helper
 
 #-------------------------------------------------------------------------------
-# Motivation: seems libconfig++ need to be compiled with same application C++ compiler, 
+# Motivation: seems libconfig++ need to be compiled with same application C++ compiler,
 # otherwise you encounter strange linker errors. (ubuntu 16.04)
 
 #arg1 is force (0 or 1) (no interactive script)
@@ -84,7 +84,7 @@ install_libconfig_from_source(){
     autoreconf -fi
     ./configure
     ret=$?;[[ $ret -ne 0 ]] && return $ret
-    make -j `nproc` > /tmp/log_compile_config 2>&1
+    make $JNPROC > /tmp/log_compile_config 2>&1
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret
     $SUDO make install
     ret=$?;[[ $ret -ne 0 ]] && popd && return $ret

--- a/build/scripts/build_helper.spgw
+++ b/build/scripts/build_helper.spgw
@@ -57,7 +57,7 @@ install_fmt() {
     cd fmt
     cmake .
     ret=$?;[[ $ret -ne 0 ]] && return $ret
-    make -j `nproc`
+    make $JNPROC
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     $SUDO make install
     cd /tmp

--- a/build/scripts/build_spgwc
+++ b/build/scripts/build_spgwc
@@ -111,9 +111,6 @@ function main()
         shift;
         ;;
       -j | --jobs)
-        # JNPROC used in build of 3rd party libraries
-        export JNPROC="-j`nproc`"
-        # used in building OAI executable
         make_args="$make_args -j`nproc`"
         shift;
         ;;
@@ -152,10 +149,10 @@ function main()
 
   if [ $var_check_install_min_deps -gt 0 ];then
     disable_ipv6
-    check_install_spgwc_min_deps  $force $debug
-    if [[ $? -ne 0 ]]; then
+    ret=$(check_install_spgwc_min_deps  $force $debug)
+    if [[ $ret -ne 0 ]]; then
         echo_error "Error: SPGW-C minimal deps installation failed"
-        return 1
+        return $ret
     else
         echo_success "SPGW-C minimal deps installation successful"
         echo_warning "SPGW-C not compiled, to compile it, re-run build_spgwc without -i option"
@@ -165,10 +162,10 @@ function main()
 
   if [ $var_check_install_deps -gt 0 ];then
     disable_ipv6
-    check_install_spgwc_deps  $force $debug
-    if [[ $? -ne 0 ]]; then
+    ret=$(check_install_spgwc_deps  $force $debug)
+    if [[ $ret -ne 0 ]]; then
         echo_error "Error: SPGW-C deps installation failed"
-        return 1
+        return $ret
     else
         echo_success "SPGW-C deps installation successful"
         echo_warning "SPGW-C not compiled, to compile it, re-run build_spgwc without -I option"

--- a/build/scripts/build_spgwc
+++ b/build/scripts/build_spgwc
@@ -111,6 +111,9 @@ function main()
         shift;
         ;;
       -j | --jobs)
+        # JNPROC used in build of 3rd party libraries
+        export JNPROC="-j`nproc`"
+        # used in building OAI executable
         make_args="$make_args -j`nproc`"
         shift;
         ;;


### PR DESCRIPTION
Disable default "make -j" for compiling third party libraries, parallel build fails sometimes in containers