### PR TITLE
DOCKER: adding correct TZ env var to dockerfiles

### DIFF
--- a/docker/Dockerfile.centos8
+++ b/docker/Dockerfile.centos8
@@ -68,12 +68,14 @@ RUN ./build_spgwc --clean --build-type Release --jobs --Verbose
 # TARGET IMAGE
 #---------------------------------------------------------------------
 FROM centos:8 as oai-spgwc
+ENV TZ=Europe/Paris
 # We install some debug tools for the moment in addition of mandatory libraries
 RUN yum update -y  \
   && yum install epel-release -y \
   && yum install dnf-plugins-core -y \
   && yum config-manager --set-enabled PowerTools \
   && yum install -y \
+    tzdata \
     psmisc \
     net-tools \
     tcpdump \

--- a/docker/Dockerfile.rhel8-2.oc4-4
+++ b/docker/Dockerfile.rhel8-2.oc4-4
@@ -66,13 +66,14 @@ RUN ./build_spgwc --clean --build-type Release --jobs --Verbose
 # TARGET IMAGE
 #---------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi8/ubi:latest as oai-spgwc
-
+ENV TZ=Europe/Paris
 # We install some debug tools for the moment in addition of mandatory libraries
 RUN yum update -y && \
     yum -y install --enablerepo="ubi-8-codeready-builder" \
-    psmisc \
-    net-tools \
-    libevent \
+      tzdata \
+      psmisc \
+      net-tools \
+      libevent \
   && yum clean all -y \
   && rm -rf /var/cache/yum
 

--- a/docker/Dockerfile.ubuntu18.04
+++ b/docker/Dockerfile.ubuntu18.04
@@ -33,11 +33,13 @@ FROM ubuntu:bionic as oai-spgwc-builder
 ARG EURECOM_PROXY
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Europe
+ENV TZ=Europe/Paris
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
-    psmisc \
-    git
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+      psmisc \
+      git
 
 # Some GIT configuration command quite useful
 RUN /bin/bash -c "if [[ -v EURECOM_PROXY ]]; then git config --global http.proxy $EURECOM_PROXY; fi"
@@ -58,17 +60,19 @@ RUN ./build_spgwc --clean --build-type Release --jobs --Verbose
 #---------------------------------------------------------------------
 FROM ubuntu:bionic as oai-spgwc
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Europe
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV TZ=Europe/Paris
 # We install some debug tools for the moment in addition of mandatory libraries
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
-    psmisc \
-    net-tools \
-    tshark \
-    libgoogle-glog0v5 \
-    libdouble-conversion1 \
-    libconfig++9v5 \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+      psmisc \
+      tzdata \
+      net-tools \
+      tshark \
+      libgoogle-glog0v5 \
+      libdouble-conversion1 \
+      libconfig++9v5 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copying executable and generated libraries
 WORKDIR /openair-spgwc/bin


### PR DESCRIPTION
Making sure that all our containers have the correct date when deployed.

The `TZ` environment variable can be modified at the deployment time in either `docker-compose` or `helm` charts