### PR TITLE
[RHEL8][DOCKER] procps-ng is not always by default in ubi

### DIFF
--- a/docker/Dockerfile.rhel8
+++ b/docker/Dockerfile.rhel8
@@ -68,6 +68,7 @@ ENV TZ=Europe/Paris
 RUN yum update -y && \
     yum -y install --enablerepo="ubi-8-codeready-builder" \
       tzdata \
+      procps-ng \
       psmisc \
       net-tools \
       libevent \

--- a/docker/Dockerfile.rhel8-2.oc4-4
+++ b/docker/Dockerfile.rhel8-2.oc4-4
@@ -72,6 +72,7 @@ RUN yum update -y && \
     yum -y install --enablerepo="ubi-8-codeready-builder" \
       tzdata \
       psmisc \
+      procps-ng \
       net-tools \
       libevent \
   && yum clean all -y \


### PR DESCRIPTION
To be able to do `pgrep` in RHEL8 containers.