### PR TITLE
IE nwi dotted formatting

### DIFF
--- a/src/pfcp/3gpp_29.244.hpp
+++ b/src/pfcp/3gpp_29.244.hpp
@@ -803,14 +803,11 @@ class pfcp_fteid_ie : public pfcp_ie {
 class pfcp_network_instance_ie : public pfcp_ie {
  public:
   std::string network_instance;
-  std::string network_instance_dotted;
 
   //--------
   explicit pfcp_network_instance_ie(const pfcp::network_instance_t& b)
       : pfcp_ie(PFCP_IE_NETWORK_INSTANCE) {
-    network_instance = b.network_instance;
-    pfcp_ie::string_to_dotted(network_instance, network_instance_dotted);
-    network_instance = network_instance_dotted;
+    pfcp_ie::string_to_dotted(b.network_instance, network_instance);
     tlv.set_length(network_instance.size());
   }
   //--------

--- a/src/pfcp/3gpp_29.244.hpp
+++ b/src/pfcp/3gpp_29.244.hpp
@@ -803,11 +803,14 @@ class pfcp_fteid_ie : public pfcp_ie {
 class pfcp_network_instance_ie : public pfcp_ie {
  public:
   std::string network_instance;
+  std::string network_instance_dotted;
 
   //--------
   explicit pfcp_network_instance_ie(const pfcp::network_instance_t& b)
       : pfcp_ie(PFCP_IE_NETWORK_INSTANCE) {
     network_instance = b.network_instance;
+    pfcp_ie::string_to_dotted(network_instance, network_instance_dotted);
+    network_instance = network_instance_dotted;
     tlv.set_length(network_instance.size());
   }
   //--------


### PR DESCRIPTION
TS 29.244 R15.0, section 8.2.4 Network Instance 
It may be encoded as a Domain Name or an
Access Point Name (APN) as per clause 9.1 of 3GPP TS 23.003 [2]. 