### PR TITLE
feat(docker): removing tcpdum from RHEL8 image

### DIFF
--- a/docker/Dockerfile.rhel8
+++ b/docker/Dockerfile.rhel8
@@ -69,7 +69,6 @@ ENV TZ=Europe/Paris
 RUN yum update -y && \
     yum -y install --enablerepo="ubi-8-codeready-builder" \
       tzdata \
-      tcpdump \
       procps-ng \
       psmisc \
       net-tools \


### PR DESCRIPTION
Sagar asked to remove `tcpdump` from standard RHEL8 build.

When deploying on cluster --> it is in another container within the pod.

For test on `cetautomatix` I now install `tcpdump` when deploying container.

Next step once it's merged, I will cleanup the dockerfile
